### PR TITLE
Fixes to satisfy lnd breaking changes

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,9 +21,7 @@ services:
       -rpcallowip=0.0.0.0/0
       -debug=0
       -zmqpubrawblock=tcp://*:28334
-      -zmqpubrawtx=tcp://*:28334
-      -zmqpubhashtx=tcp://*:28334
-      -zmqpubhashblock=tcp://*:28334
+      -zmqpubrawtx=tcp://*:28335
       -txindex=1
     expose:
      - "18443" # regtest RPC
@@ -50,7 +48,8 @@ services:
       - CHAIN=bitcoin
       - DEBUG=debug
       - BITCOIN_NODE=bitcoind
-      - ZMQ_PATH=tcp://bitcoind-regtest:28334
+      - ZMQ_PUBRAWBLOCK=tcp://bitcoind-regtest:28334
+      - ZMQ_PUBRAWTX=tcp://bitcoind-regtest:28335
       - RPC_LISTEN=:10011
       - REST_LISTEN=:8082
       - LISTEN=:9737
@@ -125,10 +124,8 @@ services:
       -testnet
       -rpcallowip=0.0.0.0/0
       -debug=0
-      -zmqpubrawblock=tcp://*:28333
+      -zmqpubrawblock=tcp://*:28332
       -zmqpubrawtx=tcp://*:28333
-      -zmqpubhashtx=tcp://*:28333
-      -zmqpubhashblock=tcp://*:28333
       -txindex=1
     expose:
      - "18332"  # testnet RPC
@@ -156,7 +153,8 @@ services:
       - CHAIN=bitcoin
       - DEBUG=debug
       - BITCOIN_NODE=bitcoind
-      - ZMQ_PATH=tcp://bitcoind-testnet:28333
+      - ZMQ_PUBRAWBLOCK=tcp://bitcoind-testnet:28332
+      - ZMQ_PUBRAWTX=tcp://bitcoind-testnet:28333
       - RPC_LISTEN=:10012
       - REST_LISTEN=:8081
       - LISTEN=:9736

--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -66,7 +66,7 @@ exec lnd \
     "--$CHAIN.$NETWORK" \
     "--$CHAIN.node"="$BITCOIN_NODE" \
     "--$BACKEND.zmqpubrawblock"="$ZMQ_PUBRAWBLOCK" \
-    "--$BACKEND.zmqpubrawtw"="$ZMQ_PUBRAWTX" \
+    "--$BACKEND.zmqpubrawtx"="$ZMQ_PUBRAWTX" \
     "--$BACKEND.rpchost"="$RPCHOST" \
     "--$BACKEND.rpcuser"="$RPCUSER" \
     "--$BACKEND.rpcpass"="$RPCPASS" \

--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -40,7 +40,8 @@ set_default() {
 
 # Set default variables if needed.
 RPCHOST=$(set_default "$RPCHOST" "127.0.0.1")
-ZMQ_PATH=$(set_default "$ZMQ_PATH" "tcp://127.0.0.1:28332")
+ZMQ_PUBRAWBLOCK=$(set_default "$ZMQ_PUBRAWBLOCK" "tcp://127.0.0.1:28332")
+ZMQ_PUBRAWTX=$(set_default "$ZMQ_PUBRAWTX" "tcp://127.0.0.1:28333")
 RPCUSER=$(set_default "$RPCUSER" "devuser")
 RPCPASS=$(set_default "$RPCPASS" "devpass")
 DEBUG=$(set_default "$DEBUG" "debug")
@@ -59,12 +60,13 @@ exec lnd \
     --restlisten="$REST_LISTEN" \
     --listen="$LISTEN" \
     --tlsextradomain="lnd-$NETWORK" \
-    --noencryptwallet \
+    --noseedbackup \
     --logdir="/data" \
     "--$CHAIN.active" \
     "--$CHAIN.$NETWORK" \
     "--$CHAIN.node"="$BITCOIN_NODE" \
-    "--$BACKEND.zmqpath"="$ZMQ_PATH" \
+    "--$BACKEND.zmqpubrawblock"="$ZMQ_PUBRAWBLOCK" \
+    "--$BACKEND.zmqpubrawtw"="$ZMQ_PUBRAWTX" \
     "--$BACKEND.rpchost"="$RPCHOST" \
     "--$BACKEND.rpcuser"="$RPCUSER" \
     "--$BACKEND.rpcpass"="$RPCPASS" \

--- a/docker/sample_dot_env
+++ b/docker/sample_dot_env
@@ -14,4 +14,5 @@ NETWORK=testnet
 CHAIN=bitcoin
 DEBUGLEVEL=debug
 BITCOIN_NODE=bitcoind
-ZMQ_PATH=tcp://bitcoind:28332
+ZMQ_PUBRAWBLOCK=tcp://bitcoind:28332
+ZMQ_PUBRAWTX=tcp://bitcoind:28333


### PR DESCRIPTION
Lightning labs have done breaking changes to LND recently. 
This includes:
- renaming  `--noencryptwallet` to `--noseedbackup`
- having `--zmqrawblock` and `--zmqrawtx` together. Note `--zmqpath` does not work anymore

`docker-compose up` was unable to run the containers because of these changes.

This PR adds those changes.

**Also note:** It is now required to run `lncli` with the flag `--network=testnet` when on testnet. Because of this your admin service crashes since it can't locate the macaroons. This also needs a fix.